### PR TITLE
punctuation: it's vs its

### DIFF
--- a/input/1-positioning.md
+++ b/input/1-positioning.md
@@ -42,7 +42,7 @@ Here's what the CSS 2.1 spec says about formatting context:
 
 > Boxes in the normal flow belong to a formatting context, which may be block or inline, but not both simultaneously. Block-level boxes participate in a block formatting context. Inline-level boxes participate in an inline formatting context. [Source](http://www.w3.org/TR/CSS2/visuren.html#normal-flow)
 
-The parent (container) establishes the formatting context for it's children based on whether the child boxes are considered to be inline-level or block-level. The terms inline-level and block-level are defined to highlight that blocks with a `display` property other than `inline` or `block` will still map to one of the two formatting contexts within normal flow. For example, `display: table` elements are considered to be block-level and `display: inline-table` elements are considered to be inline-level.
+The parent (container) establishes the formatting context for its children based on whether the child boxes are considered to be inline-level or block-level. The terms inline-level and block-level are defined to highlight that blocks with a `display` property other than `inline` or `block` will still map to one of the two formatting contexts within normal flow. For example, `display: table` elements are considered to be block-level and `display: inline-table` elements are considered to be inline-level.
 
 A block-level element is defined as:
 
@@ -311,7 +311,7 @@ In the example above:
 - even though the first parent element does not contain any text by itself, the baseline and the minimal line height of the line boxes inside that parent element is defined by the font size set on the parent element.
 - The first child element's baseline is aligned with the parent's baseline. The parent's baseline is based on the font size set on the parent element even though the parent contains no text that uses that font size. This is the "strut" mechanism in action, where the parent baseline is defined by an invisible, zero-width inline box with the element's font and line height properties.
 - Next, a series of `vertical-align: super` inline elements gradually shift the baseline, which could increase the line height further (in this case it does not because the parent font is so large). This illustrates how alignment can increase line box height.
-- Finally, the span with "super-parent" is on the same level as the first "child" element, so it's baseline is shifted according to the parent's font size's `super` position, which appears much higher than the other two super -aligned inline elements because the parent font size larger than the child font size.
+- Finally, the span with "super-parent" is on the same level as the first "child" element, so its baseline is shifted according to the parent's font size's `super` position, which appears much higher than the other two super -aligned inline elements because the parent font size larger than the child font size.
 
 Note that many of the `vertical-align` values are relative to the parent element's baseline - which is determined by the font metrics and font size of the parent element. For example, the chain of `vertical-align: super` elements gradually shifts the baseline upwards.
 
@@ -355,7 +355,7 @@ I've added a couple of additional styles to better show the different parts that
 - the inner blocks inside the container are `display: inline-block`, meaning they are treated as inline-level boxes and produce a inline formatting context, but their contents behave like `display: block` elements (for example, setting `width: 100%` works!).
 - the container has `text-align: center` to cause the inline-level blocks to be centered on each line box.
 - the content block has `vertical-align: middle` set on it, which aligns it vertically relative to all the other content on the line box.
-- a pseudo-element with `height: 100%` is added to the end of the container. It is shown in green. This is necessary because without it, the content block would simply be positioned at the top of the flow, because it would exist on it's own on a single line box, and the line box height would simply match the content block, which would mean that there would be nothing to align it with.
+- a pseudo-element with `height: 100%` is added to the end of the container. It is shown in green. This is necessary because without it, the content block would simply be positioned at the top of the flow, because it would exist on its own on a single line box, and the line box height would simply match the content block, which would mean that there would be nothing to align it with.
 - the `margin-left: -0.25em` is simply a heuristic to offset the spacing caused by the pseudo element.
 
 In short, the reason why this centering technique works is because we have forced the line height of the container to be 100% percent of the parent height, and then have asked for the centered item to be positioned at the midpoint of the sibling (green) element. Assuming that the box to be centered is less wide than the container, all of this will be placed on a single, very tall line box and the end result is vertical and horizontal centering.
@@ -429,7 +429,7 @@ Now, when the spec says "parent box", what does that mean? It turns out that the
 ---
 ```
 
-As you can see above, the child is aligned with the line boxes `x-height`, not the `parent` element's height. Since the line only contains the span plus generated anonymous inline-level boxes for the whitespace, it's height matches the line-height of the font, and nothing happens. In fact, since we are talking about `x-height` rather than height, the height of the line box doesn't even matter. The next example illustrates:
+As you can see above, the child is aligned with the line boxes `x-height`, not the `parent` element's height. Since the line only contains the span plus generated anonymous inline-level boxes for the whitespace, its height matches the line-height of the font, and nothing happens. In fact, since we are talking about `x-height` rather than height, the height of the line box doesn't even matter. The next example illustrates:
 
 ```snippet
 <div class="parent blue">
@@ -502,8 +502,8 @@ In other words, relatively positioned elements are positioned as normal, then of
 
 As you can see in the example:
 
-- the `.bar` box is offset 20 pixels up from it's normal flow position because it has `top: -20px`
-- the subsequent `.baz` box is still positioned as if the `.bar` box was in it's original position in the normal flow
+- the `.bar` box is offset 20 pixels up from its normal flow position because it has `top: -20px`
+- the subsequent `.baz` box is still positioned as if the `.bar` box was in its original position in the normal flow
 
 ## Float positioning scheme
 
@@ -620,7 +620,7 @@ The following example illustrates this behavior:
 
 In the example above:
 
-- The `new-context` div establishes a new formatting context (e.g. because it's `overflow` is not `visible`).
+- The `new-context` div establishes a new formatting context (e.g. because its `overflow` is not `visible`).
 - The float that precedes that div does not affect the line boxes of `new-context`. As you can see, the border of `new-context` is next to the border of the float, and the `new-context` box is placed next to the float.
 - The float does affect the line boxes of the following div, because it does not establish a new block formatting context. The left border of the div containing "after" is drawn underneath the float.
 

--- a/input/3-additional.md
+++ b/input/3-additional.md
@@ -8,7 +8,7 @@ Now that we have discussed how the box model properties vary across different el
 
 - *Margin collapsing* affects adjacent margins so that only the larger of two margins is applied.
 - *Negative margins*. Negative values (e.g. `-10px`) are allowed for margins, and these can be used to position content.
-- *Overflow*. When the content inside a container box is larger than it's parent or positioned at a offset that is beyond the parent's box, it overflows. The `overflow` property controls how this is handled.
+- *Overflow*. When the content inside a container box is larger than its parent or positioned at a offset that is beyond the parent's box, it overflows. The `overflow` property controls how this is handled.
 - *max-width, max-height, min-width, min-height*, Width and height can be further constrained by using the `max-width`, `max-height`, `min-width` and `min-height` properties.
 - *Pseudo-elements* allow additional elements to be generated within the selected element from CSS. They are often used to generate additional content for layout or for to provide a particular visual appearance.
 - *Stacking contexts and rendering order* determine the z-axis rendering of boxes.
@@ -59,7 +59,7 @@ If you think of the margins as boxes on their own, then you can see that two mar
 All of these cases are eligible for margin collapsing. Two margins will only collapse if they are not separated by:
 
 - content (e.g. text in line boxes)
-- padding or borders (e.g. if a parent has padding or borders, it's margins cannot collapse with the margins of it's children but otherwise they will)
+- padding or borders (e.g. if a parent has padding or borders, its margins cannot collapse with the margins of its children but otherwise they will)
 - clearance (e.g. the result of clearing a float may separate the margins enough that they cannot collapse.)
 
 What happens when margins collapse?
@@ -166,7 +166,7 @@ Negative margins shift the position where rendering happens, which can be used t
 
 ## Overflow
 
-Overflow occurs when a child element is either positioned outside its parent element, or the child element does not fit inside the dimensions of it's parent. The `overflow` property controls how the portion of the child that overflows is rendered:
+Overflow occurs when a child element is either positioned outside its parent element, or the child element does not fit inside the dimensions of its parent. The `overflow` property controls how the portion of the child that overflows is rendered:
 
 > This property specifies whether content of a block container element is clipped when it overflows the element's box. It affects the clipping of all of the element's content except any descendant elements (and their respective content and descendants) whose containing block is the viewport or an ancestor of the element. [source](http://www.w3.org/TR/2011/REC-CSS2-20110607/visufx.html#overflow)
 
@@ -254,7 +254,7 @@ As you can see:
 - if you scroll the first example, where `height: 100%` was set, you can see that the height of the div matches the parent's height and the content overflows the borders of the div.
 - in the second example, where `min-height: 100%` is used, the height of the div matches its contents.
 
-Why does this behavior occur? Because setting `min-height` leaves `height` to it's default value - `height: auto`. Then, the regular box model calculations are applied, which for a block-level element cause the box to be sized based on it's contents.
+Why does this behavior occur? Because setting `min-height` leaves `height` to its default value - `height: auto`. Then, the regular box model calculations are applied, which for a block-level element cause the box to be sized based on its contents.
 
 In contrast, setting `height: 100%` does not trigger any content-based sizing: it just sets the height of the box directly as if it was set using some other unit, such as `px` - which causes overflow in this case.
 

--- a/input/4-flexbox.md
+++ b/input/4-flexbox.md
@@ -378,7 +378,7 @@ Now that we've looked at how flex items are placed on flex lines, let's look at 
 
 Two values - `flex-grow` and `flex-shrink` - control how flex items are resized. Both of these values accept a single unitless non-negative number. Setting either value to `0` disables either growing the flex items to the size of their flex line, or shrinking them in case the flex items overflow the flex container.
 
-`flex-grow` defaults to `0` and `flex-shrink` defaults to `1`. The `flex-grow` factor is applied when the flex lines's main axis dimension is greater than it's flex items total main axis dimension; the `flex-shrink` factor is applied when the flex line's main axis dimension is less than the total of the flex items total main axis dimension.
+`flex-grow` defaults to `0` and `flex-shrink` defaults to `1`. The `flex-grow` factor is applied when the flex lines's main axis dimension is greater than its flex items total main axis dimension; the `flex-shrink` factor is applied when the flex line's main axis dimension is less than the total of the flex items total main axis dimension.
 
 Most tutorials on flexbox say something like:
 
@@ -650,7 +650,7 @@ Note `align-content` does not affect the alignment of a single-line flex contain
 
 > In a single-line flex container, the cross size of the line is the cross size of the flex container, and align-content has no effect. The main size of a line is always the same as the main size of the flex container’s content box. [source](http://www.w3.org/TR/2015/WD-css-flexbox-1-20150514/#flex-lines)
 
-For multi-line flex containers, there are two heights (or cross-axis sizes) to think about: the cross-axis size of the flex container, and the cross-axis heights of each of the flex lines. `align-content` distributes the difference between these two sums. The height of each flex line is determined by it's content:
+For multi-line flex containers, there are two heights (or cross-axis sizes) to think about: the cross-axis size of the flex container, and the cross-axis heights of each of the flex lines. `align-content` distributes the difference between these two sums. The height of each flex line is determined by its content:
 
 > In a multi-line flex container (even one with only a single line), the cross size of each line is the minimum size necessary to contain the flex items on the line (after aligment due to align-self), and the lines are aligned within the flex container with the align-content property. [source](http://www.w3.org/TR/2015/WD-css-flexbox-1-20150514/#flex-lines)
 

--- a/input/5-tricks.md
+++ b/input/5-tricks.md
@@ -53,7 +53,7 @@ Setting `position: relative` does not affect the positioning of elements in norm
 
 *Negative margins*. Margins in CSS can be negative; typically this feature is not very useful because it is hard to use correctly when the elements in question have a size that is not fixed. However, it can be useful for doing things that would otherwise be difficult. For example, if you actually want an element to overflow - such as the image carousel navigation buttons - setting a fixed negative margin can be used to intentionally cause overflow. Another prominent use case is for centering in old versions of IE, as you will see later in this chapter.
 
-*Transforms*. CSS 3 introduces a `transform: translate()` method which allows elements to be positioned using units that are relative to their own width and height. This can be a viable alternative to using negative margins. While I haven't discussed it here, it worth learning a bit about `transform: translate()`: specifically, it allows for translations to be expressed *as a percentage of the current box* - rather than as a percentage of the parent box as is typical in CSS. For example, `transform: translateX(-50%)` will move the current box to the left by half of it's width - something that would be impossible to do with negative margins for boxes that do not have a fixed, predetermined width.
+*Transforms*. CSS 3 introduces a `transform: translate()` method which allows elements to be positioned using units that are relative to their own width and height. This can be a viable alternative to using negative margins. While I haven't discussed it here, it worth learning a bit about `transform: translate()`: specifically, it allows for translations to be expressed *as a percentage of the current box* - rather than as a percentage of the parent box as is typical in CSS. For example, `transform: translateX(-50%)` will move the current box to the left by half of its width - something that would be impossible to do with negative margins for boxes that do not have a fixed, predetermined width.
 
 *margin: auto*. Knowing the two cases where setting `margin: auto` works is useful, since this allows you to make use of the builtin layouting algorithms for centering. Do you remember what the two cases are where `margin: auto` causes centering and what their prerequisites are?
 
@@ -144,7 +144,7 @@ A new formatting context:
 
 - contains floats: floats only interact with elements in the same formatting context
 - interacts with floats as a unit: that is, a block that establishes a formatting context is placed either adjacent to floating boxes, or cleared below them if it does not fit; the floats outside the formatting context cannot affect the content of the box that establishes a new formatting context
-- prevents margins from collapsing between the box establishing a formatting context and it's parent
+- prevents margins from collapsing between the box establishing a formatting context and its parent
 ```
 
 Can you describe one method for establishing a new formatting context? If not, review [this page on formatting context in MDN](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context), and consider taking another look at [chapter 1](1-positioning.html).


### PR DESCRIPTION
- "it's" is a contraction for "it is"
- "its" is the possessive pronoun
- English is confusing and inconsistent (since an "'s" ending _almost_ always means possessive) :frowning:
