### PR TITLE
Update `make` target in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Taking a look at the commit history, I think I spent about five months on this p
 The content of the book is in `./input/`. To generate the book:
 
     npm install
-    make build
+    make book
 
 which generates the output in `./output/`.
 


### PR DESCRIPTION
The README mentioned using `make build` to generate the book, but the `Makefile` doesn't define a "build" target.

I found that `make book` or `make` worked instead (`make` by itself builds the first target in the `Makefile`, which is why this works).
